### PR TITLE
fixes #1 -  bug when reading network drive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,9 @@ MANIFEST
 
 # mypy
 .mypy_cache/
+
+# pytest
+.pytest_cache/
+
+# editors
+.vscode/

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,9 +46,12 @@ def test_variables():
 def fake_partitions():
     Partition = namedtuple('Partition', ['mountpoint', 'device', 'fstype'])
 
+    test_data = os.path.join(os.path.dirname(__file__), 'data')
+
     partitions = [
-        Partition('/', os.path.join(os.path.dirname(__file__), 'data', 'image.raw'), 'NTFS'),
-        Partition(FS_ROOT, FS_ROOT, 'some_unsupported_fstype')
+        Partition('/', os.path.join(test_data, 'image.raw'), 'NTFS'),
+        Partition(FS_ROOT, FS_ROOT, 'some_unsupported_fstype'),
+        Partition(test_data, test_data, 'ext4')
     ]
 
     with patch('psutil.disk_partitions', return_value=partitions) as mock:


### PR DESCRIPTION
Fixes a bug when attempting to open a network drive with TSK.

This PR introduces a fallback to `OSFileSystem`