### PR TITLE
Outputs: set an environment variable pointing to output directory

### DIFF
--- a/fastir/common/output.py
+++ b/fastir/common/output.py
@@ -56,8 +56,9 @@ class Outputs:
         self._hostname = platform.node()
         self._dirpath = os.path.join(self._dirpath, f"{now}-{self._hostname}")
 
-        # Create the directory
+        # Create the directory and set an environment variable that may be used in COMMAND artifacts
         os.makedirs(self._dirpath)
+        os.environ['FAOUTPUTDIR'] = self._dirpath
 
         self._setup_logging()
 


### PR DESCRIPTION
It may be used in COMMAND artifacts that require a directory path