### PR TITLE
Pin python3 version on windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
     os: windows
     language: shell
     before_install:
-    - choco install --forcex86 python3
+    - choco install --forcex86 python3 --version=3.7.6
     - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
     - python -m pip install --upgrade pip wheel
 install:


### PR DESCRIPTION
Choco switched to version 3.8 by default; Last release of pyinstaller is not yet compatible with python 3.8